### PR TITLE
Create synthAcquisition wrapper of dataAcquisition

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -14,29 +14,28 @@ from sklearn.model_selection import train_test_split
 from sklearn.preprocessing import StandardScaler
 
 
-def dataAcquisition(FNAME, normalize=False, useTFIDF=False, synthetic=False):
+def dataAcquisition(FNAME, normalize=False):
     # Import counts
-    if not synthetic:
-        counts = pd.read_csv(FNAME, index_col=0)
-        doublet_labels = None
-
-    # Synthetic data doesn't have index column
-    if synthetic:
-        counts = pd.read_csv(FNAME)
-        labels = counts['labels']
-        del counts['labels']
-        doublet_labels = labels.as_matrix()
+    counts = pd.read_csv(FNAME, index_col=0)
 
     # Normalize
     if normalize:
         # Replacing with NaN makes it easier to ignore these values
         counts[counts == 0] = np.nan
 
-        if useTFIDF:
+        if normalize == "TFIDF":
             counts = normalize_tf_idf(counts)
         else:   # 10x paper normalization
             counts = normalize_counts_10x(counts)
 
+    return counts
+
+
+def synthAcquisition(FNAME, normalize=False):
+    counts = dataAcquisition(FNAME, normalize=normalize)
+    labels = counts['labels']
+    del counts['labels']
+    doublet_labels = labels.as_matrix()
     return counts, doublet_labels
 
 


### PR DESCRIPTION
Also removed redundant param useTFIDF from dataAcquisition (use
normalize=“TFIDF” instead).

Note that pandas.DataFrame.to_csv always writes the DataFrame’s index
as a additional column in the csv.