### PR TITLE
Confidence values

### DIFF
--- a/doubletdetection.py
+++ b/doubletdetection.py
@@ -5,6 +5,7 @@ import pandas as pd
 import phenograph
 import collections
 from sklearn.decomposition import PCA
+from scipy.stats import binom
 
 
 def classify(raw_counts, downsample=True, doublet_rate=0.25, k=20, n_pca=30):
@@ -212,3 +213,30 @@ def normalize_counts(raw_counts, standardizeGenes=False):
         normed = raw_counts
 
     return normed
+
+
+# TODO: Verify this does not need to incorporate num of doublets added into probs
+def doubletConfidences(orig_community_sizes, doublets_added):
+    """Return significance for doublets assigned to each community.
+
+    Args:
+        orig_community_sizes (ndarray, ndims=1): Number of cells in each
+            original community.
+        doublets_added (ndarray, ndims=1): Number of doublets added to each
+            community.
+
+    Returns:
+        ndarray, ndims=1: z-scores for each community.
+    """
+    N = np.sum(orig_community_sizes)
+    p = orig_community_sizes / N
+    k = doublets_added
+    # d_mult = multinomial(k, p)
+
+    # mu = n * p
+    # variance = np.multiply(mu, 1 - p)
+    # sd = np.sqrt(variance)
+    # z = np.divide(orig_community_sizes - mu, sd)
+
+    sf = binom.sf(k, N, p)
+    return sf

--- a/doubletdetection.py
+++ b/doubletdetection.py
@@ -48,8 +48,8 @@ def classify(raw_counts, downsample=True, doublet_rate=0.25, k=20, n_pca=30):
     pca = PCA(n_components=n_pca)
     reduced_counts = pca.fit_transform(counts)
     communities, graph, Q = phenograph.cluster(reduced_counts, k=k)
-    print("Found these communities: {0}, with sizes: {1}".format(np.unique(communities),
-          [np.count_nonzero(communities == i) for i in np.unique(communities)]))
+    print("Found communities [{0}, ... {2}], with sizes: {1}".format(min(communities),
+          [np.count_nonzero(communities == i) for i in np.unique(communities)], max(communities)))
     c_count = collections.Counter(communities)
     print('\n')
 
@@ -228,8 +228,9 @@ def doubletConfidences(orig_community_sizes, doublets_added):
     Returns:
         ndarray, ndims=1: z-scores for each community.
     """
-    N = np.sum(orig_community_sizes)
-    p = orig_community_sizes / N
+    # N = np.sum(orig_community_sizes, dtype=np.float_)
+    p = orig_community_sizes / np.sum(orig_community_sizes, dtype=np.float_)
+    N = np.sum(doublets_added)
     k = doublets_added
     # d_mult = multinomial(k, p)
 

--- a/doubletdetection.py
+++ b/doubletdetection.py
@@ -8,13 +8,16 @@ from sklearn.decomposition import PCA
 from scipy.stats import binom
 
 
-def classify(raw_counts, downsample=True, doublet_rate=0.25, k=20, n_pca=30):
+def classify(raw_counts, downsample=True, doublet_rate=0.25, k=20, n_pca=30, p_val=None):
     """Classifier for doublets in single-cell RNA-seq data.
 
     Args:
         raw_counts (ndarray): count table
         downsample (bool, optional): Downsample doublets.
         doublet_rate (TYPE, optional): Description
+        k (TYPE):
+        n_pca (TYPE):
+        p_val (float within [0,1]): Significance level to call doublets.
 
     Returns:
         ndarray, ndim=2: Normalized mixed counts (real and fake).
@@ -57,21 +60,31 @@ def classify(raw_counts, downsample=True, doublet_rate=0.25, k=20, n_pca=30):
     phenolabels = np.append(communities[:, np.newaxis], doublet_labels[:, np.newaxis], axis=1)
 
     synth_doub_count = {}
+    doublets_added = np.zeros(len(np.unique(communities)))
+    orig_community_sizes = np.zeros_like(doublets_added)
     scores = np.zeros((len(communities), 1))
     for c in np.unique(communities):
         c_indices = np.where(phenolabels[:, 0] == c)[0]
-        synth_doub_count[c] = np.sum(phenolabels[c_indices, 1]) / float(c_count[c])
+        orig_community_sizes[c] = np.count_nonzero(phenolabels[c_indices, 1] == 0)
+        doublets_added[c] = np.sum(phenolabels[c_indices, 1])
+        synth_doub_count[c] = doublets_added[c] / float(c_count[c])
         scores[c_indices] = synth_doub_count[c]
 
-    # Find a cutoff score
-    potential_cutoffs = list(synth_doub_count.values())
-    potential_cutoffs.sort(reverse=True)
-    max_dropoff = 0
-    for i in range(len(potential_cutoffs) - 1):
-        dropoff = potential_cutoffs[i] - potential_cutoffs[i + 1]
-        if dropoff > max_dropoff:
-            max_dropoff = dropoff
-            cutoff = potential_cutoffs[i]
+    if p_val is None:
+        # Find a cutoff score
+        potential_cutoffs = list(synth_doub_count.values())
+        potential_cutoffs.sort(reverse=True)
+        max_dropoff = 0
+        for i in range(len(potential_cutoffs) - 1):
+            dropoff = potential_cutoffs[i] - potential_cutoffs[i + 1]
+            if dropoff > max_dropoff:
+                max_dropoff = dropoff
+                cutoff = potential_cutoffs[i]
+    else:
+        # Find clusters with statistically significant synthetic doublet boosting
+        conf_values = doubletConfidences(orig_community_sizes, doublets_added)
+        significant = np.where(conf_values <= p_val)[0]
+        cutoff = significant
 
     return counts, scores, communities, doublet_labels, parents, cutoff
 
@@ -219,6 +232,8 @@ def normalize_counts(raw_counts, standardizeGenes=False):
 def doubletConfidences(orig_community_sizes, doublets_added):
     """Return significance for doublets assigned to each community.
 
+
+
     Args:
         orig_community_sizes (ndarray, ndims=1): Number of cells in each
             original community.
@@ -228,16 +243,15 @@ def doubletConfidences(orig_community_sizes, doublets_added):
     Returns:
         ndarray, ndims=1: z-scores for each community.
     """
-    # N = np.sum(orig_community_sizes, dtype=np.float_)
-    p = orig_community_sizes / np.sum(orig_community_sizes, dtype=np.float_)
-    N = np.sum(doublets_added)
-    k = doublets_added
-    # d_mult = multinomial(k, p)
+    assert orig_community_sizes.shape[0] == doublets_added.shape[0], (
+        "Entry for original and added doublet size required for each cluster: {0} != {1}".format(
+            orig_community_sizes.shape[0], doublets_added.shape[0]))
+    orig_cells = orig_community_sizes.reshape(-1,)
+    doublets = doublets_added.reshape(-1,)
 
-    # mu = n * p
-    # variance = np.multiply(mu, 1 - p)
-    # sd = np.sqrt(variance)
-    # z = np.divide(orig_community_sizes - mu, sd)
-
+    p = orig_cells / np.sum(orig_cells, dtype=np.float_)
+    N = np.sum(doublets)
+    k = doublets
     sf = binom.sf(k, N, p)
+
     return sf


### PR DESCRIPTION
Providing a p-value with p_val will have the classifier attempt to
identify clusters of cells that are boosted by synthetic doublets with
significance greater that p_val.

Overloading the cutoff return value in a non-sensical way, in
anticipation of class refactoring cleaning all this up.